### PR TITLE
Add background logo so inline can support social media

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -365,7 +365,13 @@ div#logo {
   background-repeat: no-repeat;
   background-size: 200px 27px;
 
-  & > a > img {
-    visibility: hidden;
+  & > a { 
+    display: block; 
+    height: 27px; 
+    width: 200px; 
+    
+    & > img {
+      visibility: hidden;
+    }
   }
 }


### PR DESCRIPTION
## Done

* Add background logo so inline can support social media

## QA

* build and see that it looks ok

## Implementation

- You need to update greenhouse.io's logo with `https://assets.ubuntu.com/v1/3c1de878-canonical-logo.png` -- the Canonical dot

![image](https://user-images.githubusercontent.com/441217/33935874-55090f56-dff5-11e7-8683-7ea87bf1b26c.png)

- At the same time, update the css

## Background

 
> I've been contacted by David Britton with the following question related
> to posting roles from Greenhouse on social media:
> 
> alice: hey, general pointer welcome... Basically, the images on social
> media sites look poor:
> https://twitter.com/davidpbritton/status/940243279425261568 -- I think
> this is due to us embedding a very wide image in a tag in our job
> postings (following spec here: http://ogp.me/).  is there a setting in
> greenhouse for us to embed a more 4:3 friendly logo?
> [15:48]  <dpb> the specific tag that gets embedded is here:     <meta
> property="og:image"
> content="https://cdn.greenhouse.io/external_greenhouse_job_boards/logos/000/010/182/original/logo-canonical-aubergine.png?1510062223"></meta>
> 