### PR TITLE
Fixed hidden checkboxes

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -178,6 +178,12 @@ strong {
     width: 100%;
   }
 
+  input[type=checkbox] {
+    float: none;
+    opacity: 1;
+    position: relative;
+  }
+
   .field-error-msg {
     padding-left: 0;
   }


### PR DESCRIPTION
The checkboxes where hidden, so I undid the vanilla changes to make it work

The post this concerned was this - https://boards.greenhouse.io/canonical/jobs/1658196

To test, either try removing the changes and adding them, via an npm build or by hand in the inspector

input[checkbox] { opasity: 1; float: left; position: absolute; }

